### PR TITLE
Adding a Dockerfile for easily run tests

### DIFF
--- a/Crdt.Tests/convergent/YataTests.fs
+++ b/Crdt.Tests/convergent/YataTests.fs
@@ -9,7 +9,7 @@ open Crdt.Convergent
 let private str (array: char[]) = System.String(array)
 
 [<Tests>]
-let tests = ftestList "A convergent YATA array" [
+let tests = testList "A convergent YATA array" [
     test "should insert elements at the beginning" {
         let a =
             Yata.zero

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Taken from/inspired by:
+# https://hamy.xyz/labs/2022-10-run-fsharp-dotnet-in-docker-console-app
+
+# **Build Project**
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+EXPOSE 80
+
+WORKDIR /source
+
+# Copy fsproj and restore all dependencies
+COPY ./Crdt/*.fsproj ./
+RUN dotnet restore
+
+# Copy source code and build / publish app and libraries
+COPY . .
+RUN dotnet publish -c release -o /app
+
+# **Run project**
+# Create new layer with runtime, copy app / libraries, then run dotnet
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
+WORKDIR /app
+COPY --from=build /app .
+#ENTRYPOINT ["dotnet", "Crdt.Tests.dll"]
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# CRDT Examples
+
 This repository contains an example implementation of various CRDTs. It serves
 mainly academic purposes (the implementations are meant to be simple and easy to
 understand, not optimized). If you want help or want to actually use them on

--- a/README.md
+++ b/README.md
@@ -1,34 +1,65 @@
-This repository contains an example implementation of various CRDTs. It serves mainly academic purposes (the implementations are meant to be simple and easy to understand, not optimized). If you want help or want to actually use them on production please let me know ;)
+This repository contains an example implementation of various CRDTs. It serves
+mainly academic purposes (the implementations are meant to be simple and easy to
+understand, not optimized). If you want help or want to actually use them on
+production please let me know ;)
 
 List of CRDTs (implemented and to be implemented):
 
 1. Convergent (state-based):
-    - Delta-based
-        - [x] Grow-only Counter
-        - [x] Positive/Negative Counter
-        - [x] Grow-only Set
-        - [x] Add Wins Observed Remove Set
-        - [x] Multi Value Register
-        - [x] YATA
-    - [x] Grow-only Counter
-    - [x] Positive/Negative Counter
-    - [x] Bounded Counter
-    - [x] Grow-only Set
-    - [x] 2 Phase Set
-    - [x] Add Wins Observed Removed Set
-    - [x] Last Write Wins Register
+
+   - Delta-based
+     - [x] Grow-only Counter
+     - [x] Positive/Negative Counter
+     - [x] Grow-only Set
+     - [x] Add Wins Observed Remove Set
+     - [x] Multi Value Register
+     - [x] YATA
+   - [x] Grow-only Counter
+   - [x] Positive/Negative Counter
+   - [x] Bounded Counter
+   - [x] Grow-only Set
+   - [x] 2 Phase Set
+   - [x] Add Wins Observed Removed Set
+   - [x] Last Write Wins Register
 
 1. Commutative (operation-based)
-    - Pure-operation based:
-        - [ ] protocol: Tagged Reliable Causal Broadcast
-        - [ ] Counter
-        - [ ] Observed Remove Set
-    - [x] protocol: Reliable Causal Broadcast
-    - [x] Counter
-    - [x] Last Write Wins Register
-    - [x] Multi Value Register
-    - [x] Observed Remove Set (add wins semantics)
-    - [x] Linear Sequence (L-Seq)
-    - [x] Replicated Growable Array (RGA)
-    - [x] Replicated Growable Array (blockwise variant)
-    - [x] JSON-like document
+   - Pure-operation based:
+     - [ ] protocol: Tagged Reliable Causal Broadcast
+     - [ ] Counter
+     - [ ] Observed Remove Set
+   - [x] protocol: Reliable Causal Broadcast
+   - [x] Counter
+   - [x] Last Write Wins Register
+   - [x] Multi Value Register
+   - [x] Observed Remove Set (add wins semantics)
+   - [x] Linear Sequence (L-Seq)
+   - [x] Replicated Growable Array (RGA)
+   - [x] Replicated Growable Array (blockwise variant)
+   - [x] JSON-like document
+
+## How to run
+
+### Requirements
+
+- Docker
+
+### Running
+
+1. Start Docker
+2. From inside the repo, run the following command
+
+```sh
+$ docker build -t crdt5 .
+```
+
+3. Run the following command to start the container
+
+```sh
+$ docker run -it crdt5
+```
+
+4. Inside the container, run the following command to run the tests
+
+```sh
+$ dotnet Crdt.Tests.dll --debug --sequenced
+```


### PR DESCRIPTION
This PR adds a Dockerfile to quickly run tests, as well as an installation guide in the README.

'Focus' mode is removed from tests on YATA so that all tests are executed.